### PR TITLE
Update main.sqf

### DIFF
--- a/SQFSM/Functions/init/fn_initSettings.sqf
+++ b/SQFSM/Functions/init/fn_initSettings.sqf
@@ -1,6 +1,6 @@
 if(isNil "SQFM_debugMode")then{ 
 	SQFSM_Version           = 0.2;
-	SQFM_debugMode          = true; // Debug-mode active 
+	SQFM_debugMode          = false; // Debug-mode active 
 	SQFM_boardTeleportDist  = 30;   // How far away a group of men can be in order to teleport into a vehicle.
 	SQFM_manualBoardingDist = 100; 
 	SQFM_travelWalkDist     = 500;

--- a/SQFSM_modules/CBA_Options/main.sqf
+++ b/SQFSM_modules/CBA_Options/main.sqf
@@ -9,7 +9,8 @@ private _versionName = ["DCO Squad FSM | ", SQFSM_Version] joinString "";
 	"CHECKBOX",
 	["Debug Mode", "Show debug messages and 3D indicators ingame."],
 	_versionName,
-	false
+	false,
+	1
 ] call CBA_fnc_addSetting;
 
 [


### PR DESCRIPTION
- added "_isGlobal" param to CBA_Options/main.sqf debugMode setting. 
- changed the default SQFM_debugMode value for fn_initSettings


Should prevent players who hadn't changed DCO SQFSM settings from automatically entering debug mode when playing on dedicated server.